### PR TITLE
Add Async Event dispatcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@
 
 Using [composer](https://getcomposer.org/download/)
 
-````
+```bash
 composer require antidot-fw/event-dispatcher
-````
+```
 
 ### Using [Laminas config Aggregator](https://docs.laminas.dev/laminas-config-aggregator/)
 
@@ -27,7 +27,7 @@ it install the library automatically
 
 #### Config
 
-````php
+```php
 <?php
 /** @var \Psr\Container\ContainerInterface $container */
 $container->set('config', [
@@ -41,10 +41,10 @@ $container->set('config', [
         ]
     ]
 ]);
-````
+```
 #### factory
 
-````php
+```php
 <?php
 
 use Antidot\Event\Container\EventDispatcherFactory;
@@ -54,17 +54,15 @@ $factory = new EventDispatcherFactory();
 
 $eventDispatcher = $factory->__invoke($container);
 $container->set(EventDispatcherInterface::class, $eventDispatcher);
-````
+```
 
 #### Async Event Dispatcher Factory
-
-
 
 ```bash
 composer require react/event-loop
 ```
 
-````php
+```php
 <?php
 
 use Antidot\Event\Container\AsyncEventDispatcherFactory;
@@ -74,7 +72,7 @@ $factory = new AsyncEventDispatcherFactory();
 
 $eventDispatcher = $factory->__invoke($container);
 $container->set(EventDispatcherInterface::class, $eventDispatcher);
-````
+```
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -56,11 +56,31 @@ $eventDispatcher = $factory->__invoke($container);
 $container->set(EventDispatcherInterface::class, $eventDispatcher);
 ````
 
+#### Async Event Dispatcher Factory
+
+
+
+```bash
+composer require react/event-loop
+```
+
+````php
+<?php
+
+use Antidot\Event\Container\AsyncEventDispatcherFactory;
+use Psr\EventDispatcher\EventDispatcherInterface;
+
+$factory = new AsyncEventDispatcherFactory();
+
+$eventDispatcher = $factory->__invoke($container);
+$container->set(EventDispatcherInterface::class, $eventDispatcher);
+````
+
 ## Usage
 
 ### Send events
 
-````php
+```php
 <?php
 
 use Psr\EventDispatcher\EventDispatcherInterface;
@@ -69,5 +89,20 @@ use Psr\EventDispatcher\EventDispatcherInterface;
 $eventDispatcher = $container->get(EventDispatcherInterface::class);
 
 $eventDispatcher->dispatch(SomeEvent::occur());
+```
 
-````
+### Send events Async mode
+
+```php
+<?php
+
+use Psr\EventDispatcher\EventDispatcherInterface;
+use React\EventLoop\Loop;
+
+/** @var \Psr\Container\ContainerInterface $container */
+$eventDispatcher = $container->get(EventDispatcherInterface::class);
+
+$eventDispatcher->dispatch(SomeEvent::occur());
+
+Loop::run()
+```

--- a/composer.json
+++ b/composer.json
@@ -14,14 +14,14 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "psr/event-dispatcher": "^1.0",
-        "react/event-loop": "^1.2"
+        "psr/event-dispatcher": "^1.0"
     },
     "require-dev": {
         "infection/infection": "^0.21.0",
         "phpro/grumphp": "^1.0",
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": "^8.0 || ^9.0",
+        "react/event-loop": "^1.2",
         "squizlabs/php_codesniffer": "^3.4",
         "symfony/var-dumper": "^4.2 || ^5.0",
         "vimeo/psalm": "^4.4"
@@ -53,6 +53,9 @@
     },
     "config": {
         "sort-packages": true
+    },
+    "suggest": {
+        "react/event-loop": "If you want to run Async Event Dispatcher implementation."
     },
     "extra": {
         "laminas": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "psr/event-dispatcher": "^1.0"
+        "psr/event-dispatcher": "^1.0",
+        "react/event-loop": "^1.2"
     },
     "require-dev": {
         "infection/infection": "^0.21.0",

--- a/src/AsyncEventDispatcher.php
+++ b/src/AsyncEventDispatcher.php
@@ -7,10 +7,9 @@ namespace Antidot\Event;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\EventDispatcher\ListenerProviderInterface;
 use Psr\EventDispatcher\StoppableEventInterface;
-use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
 
-class AsyncEventDispatcher implements EventDispatcherInterface
+final class AsyncEventDispatcher implements EventDispatcherInterface
 {
     private ListenerProviderInterface $listenerProvider;
     private LoopInterface $loop;

--- a/src/AsyncEventDispatcher.php
+++ b/src/AsyncEventDispatcher.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Antidot\Event;
+
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\EventDispatcher\ListenerProviderInterface;
+use Psr\EventDispatcher\StoppableEventInterface;
+use React\EventLoop\Loop;
+use React\EventLoop\LoopInterface;
+
+class AsyncEventDispatcher implements EventDispatcherInterface
+{
+    private ListenerProviderInterface $listenerProvider;
+    private LoopInterface $loop;
+
+    public function __construct(ListenerProviderInterface $listenerProvider, LoopInterface $loop)
+    {
+        $this->listenerProvider = $listenerProvider;
+        $this->loop = $loop;
+    }
+
+    /**
+     * @param StoppableEventInterface|object $event
+     * @return object
+     */
+    public function dispatch(object $event): object
+    {
+        $this->loop->futureTick(function () use ($event) {
+            /** @var callable[] $listeners */
+            $listeners = $this->listenerProvider->getListenersForEvent($event);
+            foreach ($listeners as $listener) {
+                if ($event instanceof StoppableEventInterface && $event->isPropagationStopped()) {
+                    return;
+                }
+                $listener($event);
+            }
+        });
+
+
+        return $event;
+    }
+}

--- a/src/Container/AsyncEventDispatcherFactory.php
+++ b/src/Container/AsyncEventDispatcherFactory.php
@@ -5,16 +5,12 @@ declare(strict_types=1);
 namespace Antidot\Event\Container;
 
 use Antidot\Event\AsyncEventDispatcher;
-use Antidot\Event\EventDispatcher;
-use Antidot\Event\ListenerProvider;
 use Psr\Container\ContainerInterface;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\EventDispatcher\ListenerProviderInterface;
 use React\EventLoop\Loop;
-use RuntimeException;
-use Throwable;
 
-class AsyncEventDispatcherFactory
+final class AsyncEventDispatcherFactory
 {
     public function __invoke(ContainerInterface $container): EventDispatcherInterface
     {

--- a/src/Container/AsyncEventDispatcherFactory.php
+++ b/src/Container/AsyncEventDispatcherFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Antidot\Event\Container;
+
+use Antidot\Event\AsyncEventDispatcher;
+use Antidot\Event\EventDispatcher;
+use Antidot\Event\ListenerProvider;
+use Psr\Container\ContainerInterface;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\EventDispatcher\ListenerProviderInterface;
+use React\EventLoop\Loop;
+use RuntimeException;
+use Throwable;
+
+class AsyncEventDispatcherFactory
+{
+    public function __invoke(ContainerInterface $container): EventDispatcherInterface
+    {
+        /** @var ListenerProviderInterface $listenerProvider */
+        $listenerProvider = $container->get(ListenerProviderInterface::class);
+
+        return new AsyncEventDispatcher($listenerProvider, Loop::get());
+    }
+}

--- a/src/Container/Config/ConfigProvider.php
+++ b/src/Container/Config/ConfigProvider.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Antidot\Event\Container\Config;
 
 use Antidot\Event\Container\EventDispatcherFactory;
+use Antidot\Event\Container\ListenerProviderFactory;
 use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\EventDispatcher\ListenerProviderInterface;
 
 class ConfigProvider
 {
@@ -17,6 +19,7 @@ class ConfigProvider
         return [
             'factories' => [
                 EventDispatcherInterface::class => EventDispatcherFactory::class,
+                ListenerProviderInterface::class => ListenerProviderFactory::class,
             ],
             'app-events' => [
 //                'event-listeners' => [

--- a/src/Container/ListenerProviderFactory.php
+++ b/src/Container/ListenerProviderFactory.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Antidot\Event\Container;
+
+use Antidot\Event\ListenerProvider;
+use Psr\Container\ContainerInterface;
+use Psr\EventDispatcher\ListenerProviderInterface;
+
+final class ListenerProviderFactory
+{
+    public function __invoke(ContainerInterface $container): ListenerProviderInterface
+    {
+        /** @var array<string, mixed> $globalConfig */
+        $globalConfig = $container->get('config');
+        /** @var array<string, array> $config */
+        $config = $globalConfig['app-events'];
+        $listenerProvider = new ListenerProvider();
+        /**
+         * @var string $eventClass
+         * @var ?array<string> $listeners
+         */
+        foreach ($config['event-listeners'] ?? [] as $eventClass => $listeners) {
+            foreach ($listeners ?? [] as $listenerId) {
+                $listenerProvider->addListener(
+                    $eventClass,
+                    static function () use ($container, $listenerId): callable {
+                        /** @var callable $listener */
+                        $listener = $container->get($listenerId);
+
+                        return $listener;
+                    }
+                );
+            }
+        }
+
+        return $listenerProvider;
+    }
+}

--- a/src/ListenerCollection.php
+++ b/src/ListenerCollection.php
@@ -6,6 +6,7 @@ namespace Antidot\Event;
 
 use IteratorAggregate;
 
+use Traversable;
 use function array_key_exists;
 
 /**
@@ -47,9 +48,9 @@ class ListenerCollection implements IteratorAggregate, ListenerCollectorInterfac
     }
 
     /**
-     * @return \Generator<mixed>|\Traversable<mixed>
+     * @return \Generator<mixed>|Traversable<mixed>
      */
-    public function getIterator()
+    public function getIterator(): Traversable
     {
         yield from $this->listeners;
     }

--- a/test/AsyncEventDispatcherTest.php
+++ b/test/AsyncEventDispatcherTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Antidot\Test\Event;
+
+use Antidot\Event\AsyncEventDispatcher;
+use Antidot\Event\EventDispatcher;
+use Antidot\Event\ListenerInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\EventDispatcher\ListenerProviderInterface;
+use Psr\EventDispatcher\StoppableEventInterface;
+use React\EventLoop\Loop;
+use StdClass;
+
+class AsyncEventDispatcherTest extends TestCase
+{
+    public function testItShouldDispatchEvents(): void
+    {
+        $event = $this->createMock(StoppableEventInterface::class);
+        $listenerProvider = $this->createMock(ListenerProviderInterface::class);
+
+        $listenerProvider
+            ->expects($this->once())
+            ->method('getListenersForEvent')
+            ->with($event)
+            ->willReturn([
+                $this->makeListener(1, $event),
+                $this->makeListener(1, $event),
+            ]);
+
+        $event
+            ->expects($this->exactly(2))
+            ->method('isPropagationStopped');
+
+        $eventDispatcher = new AsyncEventDispatcher($listenerProvider, Loop::get());
+        $eventDispatcher->dispatch($event);
+
+        Loop::run();
+    }
+
+    public function testItShouldDispatchEventOfAnyTypeOfObject(): void
+    {
+        $event = $this->createMock(StdClass::class);
+        $listenerProvider = $this->createMock(ListenerProviderInterface::class);
+
+        $listenerProvider
+            ->expects($this->once())
+            ->method('getListenersForEvent')
+            ->with($event)
+            ->willReturn([
+                $this->makeListener(1, $event),
+                $this->makeListener(1, $event),
+            ]);
+
+        $eventDispatcher = new AsyncEventDispatcher($listenerProvider, Loop::get());
+        $eventDispatcher->dispatch($event);
+
+        Loop::run();
+    }
+
+    public function testItShouldNotHandleAnyEventWhenPropagationIsStopped(): void
+    {
+        $event = $this->createMock(StoppableEventInterface::class);
+        $listenerProvider = $this->createMock(ListenerProviderInterface::class);
+
+        $listenerProvider
+            ->expects($this->once())
+            ->method('getListenersForEvent')
+            ->with($event)
+            ->willReturn([
+                $this->makeListener(1, $event),
+                $this->makeListener(0, $event),
+            ]);
+
+        $event
+            ->expects($this->exactly(2))
+            ->method('isPropagationStopped')
+            ->willReturnOnConsecutiveCalls(
+                false,
+                true
+            );
+
+        $eventDispatcher = new AsyncEventDispatcher($listenerProvider, Loop::get());
+        $eventDispatcher->dispatch($event);
+
+        Loop::run();
+    }
+
+    private function makeListener(int $callTimes, $event): ListenerInterface
+    {
+        $listener = $this->createMock(ListenerInterface::class);
+        $listener
+            ->expects($this->exactly($callTimes))
+            ->method('__invoke')
+            ->with($event);
+
+        return $listener;
+    }
+}

--- a/test/AsyncEventDispatcherTest.php
+++ b/test/AsyncEventDispatcherTest.php
@@ -10,7 +10,7 @@ use Psr\EventDispatcher\StoppableEventInterface;
 use React\EventLoop\Loop;
 use StdClass;
 
-class AsyncEventDispatcherTest extends TestCase
+final class AsyncEventDispatcherTest extends TestCase
 {
     public function testItShouldDispatchEvents(): void
     {

--- a/test/AsyncEventDispatcherTest.php
+++ b/test/AsyncEventDispatcherTest.php
@@ -3,7 +3,6 @@
 namespace Antidot\Test\Event;
 
 use Antidot\Event\AsyncEventDispatcher;
-use Antidot\Event\EventDispatcher;
 use Antidot\Event\ListenerInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\EventDispatcher\ListenerProviderInterface;

--- a/test/Container/Config/ConfigProviderTest.php
+++ b/test/Container/Config/ConfigProviderTest.php
@@ -4,8 +4,10 @@ namespace AntidotTest\Event\Container\Config;
 
 use Antidot\Event\Container\Config\ConfigProvider;
 use Antidot\Event\Container\EventDispatcherFactory;
+use Antidot\Event\Container\ListenerProviderFactory;
 use PHPUnit\Framework\TestCase;
 use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\EventDispatcher\ListenerProviderInterface;
 
 class ConfigProviderTest extends TestCase
 {
@@ -15,6 +17,7 @@ class ConfigProviderTest extends TestCase
         $this->assertSame([
             'factories' => [
                 EventDispatcherInterface::class => EventDispatcherFactory::class,
+                ListenerProviderInterface::class => ListenerProviderFactory::class,
             ],
             'app-events' => []
         ], $configProvider());

--- a/test/Container/ListenerProviderFactoryTest.php
+++ b/test/Container/ListenerProviderFactoryTest.php
@@ -9,7 +9,7 @@ use AntidotTest\Event\Container\TestEvent;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 
-class ListenerProviderFactoryTest extends TestCase
+final class ListenerProviderFactoryTest extends TestCase
 {
     public function testItShouldVConfigureListenerProviderFactory(): void
     {

--- a/test/Container/ListenerProviderFactoryTest.php
+++ b/test/Container/ListenerProviderFactoryTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Antidot\Test\Event\Container;
+
+use Antidot\Event\Container\Config\ConfigProvider;
+use Antidot\Event\Container\ListenerProviderFactory;
+use Antidot\Event\ListenerInterface;
+use AntidotTest\Event\Container\TestEvent;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+class ListenerProviderFactoryTest extends TestCase
+{
+    public function testItShouldVConfigureListenerProviderFactory(): void
+    {
+        $config = new ConfigProvider();
+        $config = array_merge($config->__invoke(), [
+            'app-events' => [
+                'event-listeners' => [
+                    TestEvent::class => [
+                        'Listener1',
+                        'Listener2',
+                    ]
+                ]
+            ]
+        ]);
+        $container = $this->createMock(ContainerInterface::class);
+        $container
+            ->expects($this->exactly(3))
+            ->method('get')
+            ->withConsecutive(['config'], ['Listener1'], ['Listener2'])
+            ->willReturnOnConsecutiveCalls(
+                $config,
+                $this->createMock(ListenerInterface::class),
+                $this->createMock(ListenerInterface::class)
+            );
+
+
+        $listenerProviderFactory = new ListenerProviderFactory();
+        $listenerProvider = $listenerProviderFactory->__invoke($container);
+        self::assertCount(2, $listenerProvider->getListenersForEvent(new TestEvent()));
+    }
+}


### PR DESCRIPTION
## Description

Add another EventDispatcherInterface implementation that sends events in React Event Loop future ticks

## Motivation and context

Allow Antidot Framework 2 to send non-blocking events 

## How has this been tested?

Is covered by unit tests, static analysis with Psalm and Phpstan, and covered by infection mutation tests.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] My pull request addresses exactly one patch/feature.
- [x] I have created a branch for this patch/feature.
- [x] Each individual commit in the pull request is meaningful.
- [x] I have added tests to cover my changes.
- [x] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
